### PR TITLE
fix(personas): move shared model constants out of route.ts

### DIFF
--- a/src/app/api/personas/character-sheet-status/route.ts
+++ b/src/app/api/personas/character-sheet-status/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createFalClient } from '@fal-ai/client';
 import { applyRateLimit } from '@/lib/rate-limit';
 import { logger } from '@/lib/logger';
-import {
-  PRIMARY_MODEL,
-  FALLBACK_MODEL,
-} from '@/app/api/personas/generate-character-sheet/route';
+import { ALLOWED_CHARACTER_SHEET_MODELS } from '@/lib/persona-models';
 
 const log = logger.child({ route: '/api/personas/character-sheet-status' });
 
@@ -14,8 +11,6 @@ export const maxDuration = 30;
 const fal = createFalClient({
   credentials: process.env.FAL_KEY,
 });
-
-const ALLOWED_MODELS = new Set<string>([PRIMARY_MODEL, FALLBACK_MODEL]);
 
 function isRecoverableError(err: any): boolean {
   const status = err?.status || 0;
@@ -40,7 +35,7 @@ export async function GET(request: NextRequest) {
     if (!requestId || !model) {
       return NextResponse.json({ error: 'Missing requestId or model' }, { status: 400 });
     }
-    if (!ALLOWED_MODELS.has(model)) {
+    if (!ALLOWED_CHARACTER_SHEET_MODELS.has(model)) {
       return NextResponse.json({ error: 'Unsupported model' }, { status: 400 });
     }
 

--- a/src/app/api/personas/generate-character-sheet/route.ts
+++ b/src/app/api/personas/generate-character-sheet/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createFalClient } from '@fal-ai/client';
 import { applyRateLimit } from '@/lib/rate-limit';
 import { createRequestLogger, logger } from '@/lib/logger';
+import { PRIMARY_MODEL, FALLBACK_MODEL } from '@/lib/persona-models';
 
 const log = logger.child({ route: '/api/personas/character-sheet' });
 
@@ -18,9 +19,6 @@ const fal = createFalClient({
 // nano-banana-pro/edit: up to 10 input reference images, max 4 output images per call
 const MAX_OUTPUT_IMAGES = 4;
 const MAX_INPUT_IMAGES = 10;
-
-export const PRIMARY_MODEL = 'fal-ai/nano-banana-pro/edit';
-export const FALLBACK_MODEL = 'fal-ai/bytedance/seedream/v4/edit';
 
 /**
  * Convert a base64 data URL to a File and upload to fal.ai storage.

--- a/src/lib/persona-models.ts
+++ b/src/lib/persona-models.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared model identifiers for the persona character-sheet generation flow.
+ * Kept outside the route files because Next.js App Router restricts
+ * what can be exported from `route.ts` to the HTTP method handlers
+ * and a small metadata whitelist (dynamic, runtime, maxDuration, etc.).
+ */
+
+export const PRIMARY_MODEL = 'fal-ai/nano-banana-pro/edit';
+export const FALLBACK_MODEL = 'fal-ai/bytedance/seedream/v4/edit';
+
+export type CharacterSheetModel = typeof PRIMARY_MODEL | typeof FALLBACK_MODEL;
+
+export const ALLOWED_CHARACTER_SHEET_MODELS: ReadonlySet<string> = new Set([
+  PRIMARY_MODEL,
+  FALLBACK_MODEL,
+]);


### PR DESCRIPTION
Next.js App Router restricts what can be exported from route.ts files to the HTTP method handlers and a small metadata whitelist (dynamic, runtime, maxDuration, etc.). The previous commit (64ca90f) exported PRIMARY_MODEL and FALLBACK_MODEL from generate-character-sheet/route.ts so the status route could import them \u2014 this fails the Next.js type check during 'next build':

  Type 'OmitWithTag<typeof ...route, ...>' does not satisfy the constraint
  '{ [x: string]: never; }'. Property 'PRIMARY_MODEL' is incompatible.

Move the constants and the ALLOWED_CHARACTER_SHEET_MODELS set into a new sibling module src/lib/persona-models.ts and import from there in both routes. Verified locally with 'npm run build' \u2014 25/25 pages built, zero type errors.